### PR TITLE
Updated the docs to reflect Leiningen 2.x changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@ Provide templated markdown output for [codox][codox].
 
 ## Usage
 
-To enable use of codox-md with codox, install it as a plugin.
-
-```bash
-lein plugin install codox-md 0.2.0
-```
-
-In your `project.clj` configure codox to use the plugin.
+If you are using Leiningen 2.x, add the codox-md dependency and
+configuration to your `project.clj` file 
 
 ```clojure
+:dependencies [[codox-md "0.2.0"]]
 :codox {:writer codox-md.writer/write-docs}
+```
+
+For Leiningen 1.x users, install the plugin via the `lein plugin` command
+(lein plugin is deprecated in Leiningen 2.x) from your shell.
+```bash
+lein plugin install codox-md 0.2.0
 ```
 
 ### Templates

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Provide templated markdown output for [codox][codox].
 
 ## Usage
 
+### Leiningen 2.x
+
 If you are using Leiningen 2.x, add the codox-md dependency and
 configuration to your `project.clj` file.
 
@@ -11,6 +13,8 @@ configuration to your `project.clj` file.
 :dependencies [[codox-md "0.2.0"]]
 :codox {:writer codox-md.writer/write-docs}
 ```
+
+### Leiningen 1.x
 
 For Leiningen 1.x users, install the plugin via the `lein plugin` command
 from your shell (lein plugin is deprecated in Leiningen 2.x)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provide templated markdown output for [codox][codox].
 ## Usage
 
 If you are using Leiningen 2.x, add the codox-md dependency and
-configuration to your `project.clj` file 
+configuration to your `project.clj` file.
 
 ```clojure
 :dependencies [[codox-md "0.2.0"]]
@@ -13,9 +13,16 @@ configuration to your `project.clj` file
 ```
 
 For Leiningen 1.x users, install the plugin via the `lein plugin` command
-(lein plugin is deprecated in Leiningen 2.x) from your shell.
+from your shell (lein plugin is deprecated in Leiningen 2.x)
 ```bash
 lein plugin install codox-md 0.2.0
+```
+
+and configure it in the project.clj file.
+
+```clojure
+:dependencies [[codox-md "0.2.0"]]
+:codox {:writer codox-md.writer/write-docs}
 ```
 
 ### Templates

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ lein plugin install codox-md 0.2.0
 and configure it in the project.clj file.
 
 ```clojure
-:dependencies [[codox-md "0.2.0"]]
 :codox {:writer codox-md.writer/write-docs}
 ```
 


### PR DESCRIPTION
Apparently Leiningen 2.x deprecates the `lein plugin` command.  I added docs to reflect that in README.md.
